### PR TITLE
Remove always-on watermark, add CLI options

### DIFF
--- a/AsStrongAsFuck/AsStrongAsFuck.csproj
+++ b/AsStrongAsFuck/AsStrongAsFuck.csproj
@@ -15,7 +15,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -37,6 +37,9 @@
     <Reference Include="dnlib, Version=1.5.0.1500, Culture=neutral, PublicKeyToken=50e96378b6e77999, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>libs\dnlib.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Options, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Options.6.12.0.148\lib\net40\Mono.Options.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -79,6 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AsStrongAsFuck/Program.cs
+++ b/AsStrongAsFuck/Program.cs
@@ -3,28 +3,96 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Mono.Options;
 
 namespace AsStrongAsFuck
 {
     class Program
     {
+        static string file = System.IO.Path.GetFileNameWithoutExtension(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
         public static Worker Worker { get; set; }
         public static void Main(string[] args)
         {
-            Console.WriteLine("AsStrongAsFuck by Charter.");
-            Console.Write("Input an assembly: ");
-            string path = Console.ReadLine();
-            Worker = new Worker(path);
-            Console.WriteLine("Choose options to obfuscate: ");
 
-            for (int i = 0; i < Worker.Obfuscations.Count; i++)
+            bool show_help = false;
+            string input_path="";
+            string output_path="";
+            int[] obfuscations = { };
+            List<string> extra;
+
+
+            var p = new OptionSet() {
+
+                { "i|input=", "Input assembly", option => input_path=option },
+                { "o|output=", "Destination of the asssembly", option => output_path=option },
+                { "b|obfuscations=", "Obfuscations", option =>
+                        {
+                string[] obf_str=option.Split(',');
+                obfuscations=new int[obf_str.Length];
+                for (int i=0; i<obf_str.Length;i++) {
+                                obfuscations[i]=int.Parse(obf_str[i]);
+                                }
+                    }
+                        },
+                { "?|help|h", "Prints out the options.", option => show_help = option != null }
+
+
+
+            };
+
+            try
             {
-                Console.WriteLine(i + 1 + ") " + Worker.Obfuscations[i]);
+                extra = p.Parse(args);
+                if (show_help)
+                {
+                    ShowHelp(p);
+                    return;
+                }
+                if (String.IsNullOrEmpty(input_path))
+                {
+                    throw new OptionException("input_path is required","input_path");
+                }
+                if (String.IsNullOrEmpty(output_path))
+                {
+                    throw new OptionException("output_path is required", "input_path");
+                }
+                if (obfuscations.Length == 0)
+                {
+                    throw new OptionException("You must specify at least one obfuscation", "obfuscations");
+                }
             }
-            string opts = Console.ReadLine();
-            Worker.ExecuteObfuscations(opts);
-            Worker.Save();
-            Console.ReadLine();
+            catch (OptionException e)
+            {
+                Console.Write($"{file}: ");
+                Console.WriteLine(e.Message);
+                Console.WriteLine($"Try `{file} --help' for more information.");
+                return;
+            }
+            Console.WriteLine("AsStrongAsFuck by Charter.");
+
+            Worker = new Worker(input_path);
+            //Console.WriteLine("Choose options to obfuscate: ");
+
+            //for (int i = 0; i < Worker.Obfuscations.Count; i++)
+            //{
+            //    Console.WriteLine(i + 1 + ") " + Worker.Obfuscations[i]);
+            //}
+            //string opts = Console.ReadLine();
+            Worker.ExecuteObfuscations(obfuscations);
+            Worker.Save(output_path);
+            //Console.ReadLine();
         }
-    }
+        private static void ShowHelp(OptionSet p)
+        {
+            //Console.WriteLine("Showing help");
+            Console.WriteLine($"Usage {file}: ");
+            p.WriteOptionDescriptions(Console.Out);
+            var w = new Worker(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName); // ugly, but I CBA
+            for (int i = 0; i < w.Obfuscations.Count; i++)
+            {
+                Console.WriteLine(i + 1 + ") " + w.Obfuscations[i]);
+            }
+        }
+    } // Program
+
 }

--- a/AsStrongAsFuck/Worker.cs
+++ b/AsStrongAsFuck/Worker.cs
@@ -66,15 +66,15 @@ namespace AsStrongAsFuck
             Module.CustomAttributes.Add(attr);
         }
 
-        public void ExecuteObfuscations(string param)
+        public void ExecuteObfuscations(int[] obfuscations)
         {
-            Code = param;
-            var shit = param.ToCharArray().ToList();
+            //Code = param;
+            //var shit = param.ToCharArray().ToList();
             Stopwatch watch = new Stopwatch();
             watch.Start();
-            foreach (var v in shit)
+            foreach (var v in obfuscations)
             {
-                int i = int.Parse(v.ToString()) - 1;
+                int i = v - 1;
                 Logger.LogMessage("Executing ", Obfuscations[i], ConsoleColor.Magenta);
                 Type type = OwnAssembly.GetTypes().First(x => x.Name == Obfuscations[i]);
                 var instance = Activator.CreateInstance(type);
@@ -244,20 +244,21 @@ namespace AsStrongAsFuck
             }
         }
 
-        public void Save()
+        public void Save(string outputpath)
         {
-            Watermark();
-            Logger.LogMessage("Saving as ", Path + ".obfuscated", ConsoleColor.Yellow);
+
+            //Watermark();
+            Logger.LogMessage("Saving as ", outputpath, ConsoleColor.Yellow);
             ModuleWriterOptions opts = new ModuleWriterOptions(Module);
             opts.Logger = DummyLogger.NoThrowInstance;
-            Assembly.Write(Path + ".obfuscated", opts);
+            Assembly.Write(outputpath, opts);
             Console.WriteLine("Saved.");
         }
 
         public byte[] SaveToArray()
         {
             MemoryStream stream = new MemoryStream();
-            Watermark();
+            //Watermark();
             ModuleWriterOptions opts = new ModuleWriterOptions(Module);
             opts.Logger = DummyLogger.NoThrowInstance;
             Assembly.Write(stream, opts);

--- a/AsStrongAsFuck/packages.config
+++ b/AsStrongAsFuck/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Options" version="6.12.0.148" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
No longer automatically watermarks
CLI options via Mono.Options allow batch processing